### PR TITLE
Wrap check to handle old sar versions

### DIFF
--- a/check_sar_perf.py
+++ b/check_sar_perf.py
@@ -187,4 +187,8 @@ def Main(args):
     sys.exit(ERR_OK)
 
 if __name__ == '__main__':
-    Main(sys.argv)
+    try:
+        Main(sys.argv)
+    except:
+        print 'Unexpected Error'
+        exit 3


### PR DESCRIPTION
The SwapUtil command will fail on old versions of sar/sysstat. To work around this and possible other problems, return 3 on exceptions